### PR TITLE
oslo.messaging driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ dmypy.json
 
 # End of https://www.gitignore.io/api/python
 
+.stestr/

--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+test_path=./ironic_prometheus_exporter/tests
+top_path=./

--- a/README.md
+++ b/README.md
@@ -12,6 +12,5 @@ After install the driver you will need to update the :ironic.conf: and add
 [oslo_messaging_notifications]
 driver = prometheus_exporter
 transport_url = fake://
-file_dir=/tmp/ironic_prometheus_exporter
-file_name=myfile.txt
+file_path=/tmp/ironic_prometheus_exporter/myfile.txt
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 Ironic Prometheus Exporter
 ==========================
 
+
+Configuration
+=============
+
+After install the driver you will need to update the :ironic.conf: and add
+:file_dir: and :file_name: options
+
+```
+[oslo_messaging_notifications]
+driver = prometheus_exporter
+transport_url = fake://
+file_dir=/tmp/ironic_prometheus_exporter
+file_name=myfile.txt
+```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-Ironic Prometheus Exporter
-==========================
+# Ironic Prometheus Exporter
 
 
-Configuration
-=============
+
+### Configuration
 
 After install the driver you will need to update the :ironic.conf: and add
 :file_dir: and :file_name: options

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 ### Configuration
 
 After install the driver you will need to update the :ironic.conf: and add
-:file_dir: and :file_name: options
+:file_path: option (the file extension should be .json) 
 
 ```
 [oslo_messaging_notifications]
 driver = prometheus_exporter
 transport_url = fake://
-file_path=/tmp/ironic_prometheus_exporter/myfile.txt
+file_path=/tmp/ironic_prometheus_exporter/metrics.json
 ```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,32 @@
-# Ironic Prometheus Exporter
+# Ironic Prometheus Exporter #
 
 
+### Installation ###
 
-### Configuration
+1 - Clone the repository in the machine where ironic is installed.
+```
+$ git clone https://github.com/metalkube/ironic-prometheus-exporter
+```
+2 - Install the driver (may require sudo permisions)
+```
+$ cd ironic-prometheus-exporter
+$ python setup.py install
+```
+3- Verify if the driver is installed
+```
+$ python verify_installation.py
+```
+Output in case of a successful instalation:
+`prometheus_exporter driver found.`
+Output in case of an unsuccessful instalation:
+`prometheus_exporter driver not found.`
+`Available drivers: ['log', 'messagingv2', 'noop', 'routing', 'test', 'messaging']`
+
+
+### Configuration ###
 
 After install the driver you will need to update the :ironic.conf: and add
-:file_path: option (the file extension should be .json) 
+:file_path: option (the file extension should be .json)
 
 ```
 [oslo_messaging_notifications]

--- a/ironic_prometheus_exporter/__init__.py
+++ b/ironic_prometheus_exporter/__init__.py
@@ -1,0 +1,7 @@
+from oslo_config import cfg
+
+from ironic_prometheus_exporter import messaging
+
+CONF = cfg.CONF
+
+messaging.register_opts(CONF)

--- a/ironic_prometheus_exporter/messaging.py
+++ b/ironic_prometheus_exporter/messaging.py
@@ -9,18 +9,19 @@ prometheus_opts = [
 ]
 
 
+def register_opts(conf):
+    conf.register_opts(prometheus_opts, group='oslo_messaging_notifications')
+
+
 class PrometheusFileDriver(notifier.Driver):
 
     "Publish notifications into a File to be used by Prometheus"
 
     def __init__(self, conf, topics, transport):
-        conf.register_opts(prometheus_opts,
-                           group='oslo_messaging_notifications')
-        self.conf = conf
-        if not os.path.exists(self.conf.oslo_messaging_notifications.file_dir):
-            os.makedirs(self.conf.oslo_messaging_notifications.file_dir)
-        self.file_dir = self.conf.oslo_messaging_notifications.file_dir
-        self.file_name = self.conf.oslo_messaging_notifications.file_name
+        self.file_dir = conf.oslo_messaging_notifications.file_dir
+        self.file_name = conf.oslo_messaging_notifications.file_name
+        if not os.path.exists(self.file_dir):
+            os.makedirs(self.file_dir)
         super(PrometheusFileDriver, self).__init__(conf, topics, transport)
 
     def notify(self, ctxt, message, priority, retry):

--- a/ironic_prometheus_exporter/messaging.py
+++ b/ironic_prometheus_exporter/messaging.py
@@ -1,0 +1,29 @@
+import os
+
+from oslo_config import cfg
+from oslo_messaging.notify import notifier
+
+prometheus_opts = [
+    cfg.StrOpt('file_name', required=True),
+    cfg.StrOpt('file_dir', required=True)
+]
+
+
+class PrometheusFileDriver(notifier.Driver):
+
+    "Publish notifications into a File to be used by Prometheus"
+
+    def __init__(self, conf, topics, transport):
+        conf.register_opts(prometheus_opts,
+                           group='oslo_messaging_notifications')
+        self.conf = conf
+        if not os.path.exists(self.conf.oslo_messaging_notifications.file_dir):
+            os.makedirs(self.conf.oslo_messaging_notifications.file_dir)
+        self.file_dir = self.conf.oslo_messaging_notifications.file_dir
+        self.file_name = self.conf.oslo_messaging_notifications.file_name
+        super(PrometheusFileDriver, self).__init__(conf, topics, transport)
+
+    def notify(self, ctxt, message, priority, retry):
+        prometheus_file = open((self.file_dir + '/' + self.file_name), 'w')
+        prometheus_file.write(str(message))
+        prometheus_file.close()

--- a/ironic_prometheus_exporter/messaging.py
+++ b/ironic_prometheus_exporter/messaging.py
@@ -4,8 +4,7 @@ from oslo_config import cfg
 from oslo_messaging.notify import notifier
 
 prometheus_opts = [
-    cfg.StrOpt('file_name', required=True),
-    cfg.StrOpt('file_dir', required=True)
+    cfg.StrOpt('file_path', required=True),
 ]
 
 
@@ -14,17 +13,15 @@ def register_opts(conf):
 
 
 class PrometheusFileDriver(notifier.Driver):
-
-    "Publish notifications into a File to be used by Prometheus"
+    """Publish notifications into a File to be used by Prometheus"""
 
     def __init__(self, conf, topics, transport):
-        self.file_dir = conf.oslo_messaging_notifications.file_dir
-        self.file_name = conf.oslo_messaging_notifications.file_name
-        if not os.path.exists(self.file_dir):
-            os.makedirs(self.file_dir)
+        self.file_path = conf.oslo_messaging_notifications.file_path
+        if not os.path.exists(os.path.dirname(self.file_path)):
+            os.makedirs(os.path.dirname(self.file_path))
         super(PrometheusFileDriver, self).__init__(conf, topics, transport)
 
     def notify(self, ctxt, message, priority, retry):
-        prometheus_file = open((self.file_dir + '/' + self.file_name), 'w')
+        prometheus_file = open(self.file_path, 'w')
         prometheus_file.write(str(message))
         prometheus_file.close()

--- a/ironic_prometheus_exporter/tests/test_driver.py
+++ b/ironic_prometheus_exporter/tests/test_driver.py
@@ -9,14 +9,11 @@ class TestPrometheusFileNotifier(test_utils.BaseTestCase):
         super(TestPrometheusFileNotifier, self).setUp()
 
     def test_notifier(self):
-        self.config(file_name='test.txt',
-                    file_dir='/tmp/ironic_prometheus_exporter',
+        self.config(file_path='/tmp/ironic_prometheus_exporter/test.txt',
                     group='oslo_messaging_notifications')
         transport = oslo_messaging.get_notification_transport(self.conf)
         oslo_messaging.Notifier(transport, driver='prometheus_exporter',
                                 topics=['my_topics'])
 
-        self.assertEqual(self.conf.oslo_messaging_notifications.file_name,
-                         "test.txt")
-        self.assertEqual(self.conf.oslo_messaging_notifications.file_dir,
-                         '/tmp/ironic_prometheus_exporter')
+        self.assertEqual(self.conf.oslo_messaging_notifications.file_path,
+                         "/tmp/ironic_prometheus_exporter/test.txt")

--- a/ironic_prometheus_exporter/tests/test_driver.py
+++ b/ironic_prometheus_exporter/tests/test_driver.py
@@ -9,15 +9,14 @@ class TestPrometheusFileNotifier(test_utils.BaseTestCase):
         super(TestPrometheusFileNotifier, self).setUp()
 
     def test_notifier(self):
-        transport = oslo_messaging.get_notification_transport(self.conf)
-        my_notifier = oslo_messaging.Notifier(transport,
-                                              driver='prometheus_exporter',
-                                              topics=['my_topics'])
         self.config(file_name='test.txt',
                     file_dir='/tmp/ironic_prometheus_exporter',
                     group='oslo_messaging_notifications')
+        transport = oslo_messaging.get_notification_transport(self.conf)
+        oslo_messaging.Notifier(transport, driver='prometheus_exporter',
+                                topics=['my_topics'])
+
         self.assertEqual(self.conf.oslo_messaging_notifications.file_name,
                          "test.txt")
         self.assertEqual(self.conf.oslo_messaging_notifications.file_dir,
                          '/tmp/ironic_prometheus_exporter')
-        my_notifier.debug({}, "My Event", 'Payload')

--- a/ironic_prometheus_exporter/tests/test_driver.py
+++ b/ironic_prometheus_exporter/tests/test_driver.py
@@ -1,0 +1,23 @@
+import oslo_messaging
+
+from oslo_messaging.tests import utils as test_utils
+
+
+class TestPrometheusFileNotifier(test_utils.BaseTestCase):
+
+    def setUp(self):
+        super(TestPrometheusFileNotifier, self).setUp()
+
+    def test_notifier(self):
+        transport = oslo_messaging.get_notification_transport(self.conf)
+        my_notifier = oslo_messaging.Notifier(transport,
+                                              driver='prometheus_exporter',
+                                              topics=['my_topics'])
+        self.config(file_name='test.txt',
+                    file_dir='/tmp/ironic_prometheus_exporter',
+                    group='oslo_messaging_notifications')
+        self.assertEqual(self.conf.oslo_messaging_notifications.file_name,
+                         "test.txt")
+        self.assertEqual(self.conf.oslo_messaging_notifications.file_dir,
+                         '/tmp/ironic_prometheus_exporter')
+        my_notifier.debug({}, "My Event", 'Payload')

--- a/ironic_prometheus_exporter/tests/test_driver.py
+++ b/ironic_prometheus_exporter/tests/test_driver.py
@@ -9,11 +9,11 @@ class TestPrometheusFileNotifier(test_utils.BaseTestCase):
         super(TestPrometheusFileNotifier, self).setUp()
 
     def test_notifier(self):
-        self.config(file_path='/tmp/ironic_prometheus_exporter/test.txt',
+        self.config(file_path='/tmp/ironic_prometheus_exporter/test.json',
                     group='oslo_messaging_notifications')
         transport = oslo_messaging.get_notification_transport(self.conf)
         oslo_messaging.Notifier(transport, driver='prometheus_exporter',
                                 topics=['my_topics'])
 
         self.assertEqual(self.conf.oslo_messaging_notifications.file_path,
-                         "/tmp/ironic_prometheus_exporter/test.txt")
+                         "/tmp/ironic_prometheus_exporter/test.json")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pbr!=2.1.0,>=2.0.0 # Apache-2.0
 flake8
 stevedore>=1.20.0 # Apache-2.0
 oslo.messaging!=9.0.0 # Apache-2.0
+oslotest>=2.15.0 # Apache-2.0
+stestr>=2.0.0 # Apache-2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ pbr!=2.1.0,>=2.0.0 # Apache-2.0
 flake8
 stevedore>=1.20.0 # Apache-2.0
 oslo.messaging!=9.0.0 # Apache-2.0
-oslotest>=2.15.0 # Apache-2.0
 stestr>=2.0.0 # Apache-2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,4 @@ packages =
 
 [entry_points]
 oslo.messaging.notify.drivers =
-    simplefile = ironic_prometheus_exporter.messaging:FileDriver
+    prometheus_exporter = ironic_prometheus_exporter.messaging:PrometheusFileDriver

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ setenv =
    VIRTUAL_ENV={envdir}
    PYTHONWARNINGS=default::DeprecationWarning
 deps  = -r{toxinidir}/requirements.txt
-commands = python setup.py test 
+commands = stestr run {posargs}
 
 [testenv:pep8]
 basepython = python3
@@ -22,7 +22,6 @@ commands = {posargs}
 
 [flake8]
 ignore = E129
-
 show-source = True
 builtins = _
 exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build

--- a/verify_installation.py
+++ b/verify_installation.py
@@ -1,0 +1,13 @@
+import stevedore
+
+driver_list = stevedore.ExtensionManager(
+    'oslo.messaging.notify.drivers',
+    invoke_on_load=False,
+    propagate_map_exceptions=True
+)
+
+if 'prometheus_exporter' in driver_list.names():
+    print('prometheus_exporter driver found.')
+else:
+    print('prometheus_exporter driver not found.')
+    print('Available drivers: %s' % driver_list.names())


### PR DESCRIPTION
This PR adds a new driver for oslo.messaging notifier to capture the messages and write to a file.
The driver is installed under the oslo.messaging namespace.

To cofigure the driver is necessary to edit the `oslo_messaging_notifications` section in `ironic.conf` 
```
[oslo_messaging_notifications]
driver = prometheus_exporter
transport_url = fake://
file_dir=/tmp/ironic_prometheus_exporter
file_name=myfile.txt
```