### PR TITLE
Updates and Fixes for metrics labels

### DIFF
--- a/ironic_prometheus_exporter/messaging.py
+++ b/ironic_prometheus_exporter/messaging.py
@@ -33,11 +33,16 @@ class PrometheusFileDriver(notifier.Driver):
             if message['event_type'] == 'hardware.ipmi.metrics':
                 registry = CollectorRegistry()
                 node_name = message['payload']['node_name']
+                node_uuid = message['payload']['node_uuid']
+                instance_uuid = message['payload']['instance_uuid']
+                timestamp = message['payload']['timestamp']
                 node_payload = message['payload']['payload']
+                ipmi.timestamp_registry(timestamp, node_name, node_uuid,
+                                        instance_uuid, registry)
                 for category in node_payload:
                     ipmi.category_registry(category.lower(),
                                            node_payload[category], node_name,
-                                           registry)
+                                           node_uuid, instance_uuid, registry)
                 nodeFile = os.path.join(self.location, node_name)
                 write_to_textfile(nodeFile, registry)
         except Exception as e:

--- a/ironic_prometheus_exporter/parsers/ipmi.py
+++ b/ironic_prometheus_exporter/parsers/ipmi.py
@@ -1,6 +1,7 @@
 import logging
 import re
 
+from datetime import datetime
 from prometheus_client import Gauge
 
 # NOTE (iurygregory): most of the sensor readings come in the ipmi format
@@ -23,23 +24,30 @@ def metric_names(payload, prefix, sufix, **kwargs):
     special_label = kwargs.get('special_label')
     for entry in payload:
         if special_label == 'fan':
-            e = re.sub(r'[\d].*$', '', entry.lower())
-            e = re.sub(r'[\(\)]', '', e).split()
+            # NOTE (iurygregory): regex to remove a sequence of numbers and
+            # letters that comes after the fan sensor name.
+            # e.g: 'Fan4B (0x43)' will be 'fan (0x43)'
+            e = re.sub(r'fan\d*[a-z]*', 'fan', entry.lower())
+            # NOTE (iurygregory): regex to remove brackets and it content
+            # e.g: 'fan (0x43)' will turn into ['fan']
+            e = re.sub(r'\(.*\)', '', e).split()
             label = '_'.join(e)
         else:
+            # NOTE (iurygregory): regex to remove all numbers
             e = re.sub(r"[\d]+", "", entry).lower().split()
             label = '_'.join(e[:-1]).replace('-', '_')
 
+        unit = ''
         if extract_unit:
             sensor_read = payload[entry]['Sensor Reading'].split()
             if len(sensor_read) > 1:
-                sufix = '_' + sensor_read[-1].lower()
+                unit = '_' + sensor_read[-1].lower()
 
         if special_label == 'memory':
             if 'mem' not in label and 'memory' not in label:
                 label = 'memory_' + label
 
-        metric_name = re.sub(r'[\W]', '_', prefix + label + sufix)
+        metric_name = re.sub(r'[\W]', '_', prefix + label + sufix + unit)
         if metric_name[0].isdigit():
             metric_name = metric_name.lstrip('0123456789')
         if metric_name in metric_dic:
@@ -49,7 +57,7 @@ def metric_names(payload, prefix, sufix, **kwargs):
     return metric_dic
 
 
-def extract_labels(entries, payload, node_name):
+def extract_labels(entries, payload, node_name, node_uuid, instance_uuid):
     """ This function extract the labels to be used by a metric
 
     If a metric has many entries we add the 'Sensor ID' information as label
@@ -71,17 +79,28 @@ def extract_labels(entries, payload, node_name):
     LOG.info('extract_labels function called with: entries=%s | payload=%s | \
              node_name=%s' % (str(entries), str(payload), node_name))
     if len(entries) == 1:
+        status = payload[entries[0]].get('Status')
         labels = {'node_name': node_name,
-                  'entity_id': payload[entries[0]]['Entity ID']}
+                  'node_uuid': node_uuid,
+                  'instance_uuid': instance_uuid,
+                  'entity_id': payload[entries[0]]['Entity ID'],
+                  'sensor_id': payload[entries[0]]['Sensor ID']}
+        if status:
+            labels['status'] = status
         return {entries[0]: labels}
     entries_labels = {}
     for entry in entries:
         try:
             entity_id = payload[entry]['Entity ID']
             sensor_id = payload[entry]['Sensor ID']
+            status = payload[entry].get('Status')
             metric_label = {'node_name': node_name,
+                            'node_uuid': node_uuid,
+                            'instance_uuid': instance_uuid,
                             'entity_id': entity_id,
                             'sensor_id': sensor_id}
+            if status:
+                metric_label['status'] = status
             entries_labels[entry] = metric_label
         except Exception as e:
             LOG.exception(e)
@@ -114,11 +133,13 @@ def extract_values(entries, payload, use_ipmi_format=True):
     return values
 
 
-def prometheus_format(payload, node_name, ipmi_metric_registry,
-                      available_metrics, use_ipmi_format):
+def prometheus_format(payload, node_name, node_uuid, instance_uuid,
+                      ipmi_metric_registry, available_metrics,
+                      use_ipmi_format):
     for metric in available_metrics:
         entries = available_metrics[metric]
-        labels = extract_labels(entries, payload, node_name)
+        labels = extract_labels(entries, payload, node_name, node_uuid,
+                                instance_uuid)
         values = extract_values(entries, payload,
                                 use_ipmi_format=use_ipmi_format)
         if all(v is None for v in values.values()):
@@ -132,35 +153,67 @@ def prometheus_format(payload, node_name, ipmi_metric_registry,
 
 
 CATEGORY_PARAMS = {
-    'management': {'prefix': 'baremetal_', 'sufix': '',
-                   'extra_params': {}, 'use_ipmi_format': True},
-    'temperature': {'prefix': 'baremetal_', 'sufix': '_celsius',
-                    'extra_params': {}, 'use_ipmi_format': False},
-    'system': {'prefix': 'baremetal_system_', 'sufix': '', 'extra_params': {},
+    'management': {'prefix': 'baremetal_',
+                   'sufix': '',
+                   'extra_params': {},
+                   'use_ipmi_format': True},
+    'temperature': {'prefix': 'baremetal_',
+                    'sufix': '_celsius',
+                    'extra_params': {},
+                    'use_ipmi_format': False},
+    'system': {'prefix': 'baremetal_system_',
+               'sufix': '',
+               'extra_params': {},
                'use_ipmi_format': True},
-    'current': {'prefix': 'baremetal_', 'sufix': '', 'extra_params': {},
+    'current': {'prefix': 'baremetal_',
+                'sufix': '',
+                'extra_params': {},
                 'use_ipmi_format': False},
-    'version': {'prefix': 'baremetal_', 'sufix': '', 'extra_params': {},
+    'version': {'prefix': 'baremetal_',
+                'sufix': '',
+                'extra_params': {},
                 'use_ipmi_format': True},
-    'memory': {'prefix': 'baremetal_', 'sufix': '',
+    'memory': {'prefix': 'baremetal_',
+               'sufix': '',
                'extra_params': {'special_label': 'memory'},
                'use_ipmi_format': True},
-    'power': {'prefix': 'baremetal_power_', 'sufix': '', 'extra_params': {},
+    'power': {'prefix': 'baremetal_power_',
+              'sufix': '',
+              'extra_params': {},
               'use_ipmi_format': True},
-    'watchdog2': {'prefix': 'baremetal_', 'sufix': '', 'extra_params': {},
+    'watchdog2': {'prefix': 'baremetal_',
+                  'sufix': '',
+                  'extra_params': {},
                   'use_ipmi_format': True},
-    'fan': {'prefix': 'baremetal_', 'sufix': '',
+    'fan': {'prefix': 'baremetal_',
+            'sufix': '',
             'extra_params': {'extract_unit': True, 'special_label': 'fan'},
-            'use_ipmi_format': True}
+            'use_ipmi_format': True},
 }
 
 
-def category_registry(category_name, payload, node_name, ipmi_metric_registry):
+def category_registry(category_name, payload, node_name, node_uuid,
+                      instance_uuid, ipmi_metric_registry):
     if category_name in CATEGORY_PARAMS:
         prefix = CATEGORY_PARAMS[category_name]['prefix']
         sufix = CATEGORY_PARAMS[category_name]['sufix']
         extra = CATEGORY_PARAMS[category_name]['extra_params']
         available_metrics = metric_names(payload, prefix, sufix, **extra)
         use_ipmi_format = CATEGORY_PARAMS[category_name]['use_ipmi_format']
-        prometheus_format(payload, node_name, ipmi_metric_registry,
-                          available_metrics, use_ipmi_format)
+        prometheus_format(payload, node_name, node_uuid, instance_uuid,
+                          ipmi_metric_registry, available_metrics,
+                          use_ipmi_format)
+
+
+def timestamp_registry(timestamp, node_name, node_uuid, instance_uuid,
+                       ipmi_metric_registry):
+    metric = 'baremetal_last_payload_timestamp'
+    labels = {'node_name': node_name,
+              'node_uuid': node_uuid,
+              'instance_uuid': instance_uuid}
+    dt_1970 = datetime(1970, 1, 1, 0, 0, 0)
+    dt_timestamp = datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S.%f')
+    value = int((dt_timestamp - dt_1970).total_seconds())
+    g = Gauge(metric, '', labelnames=labels.keys(),
+              registry=ipmi_metric_registry)
+    g.labels(**labels).set(value)

--- a/ironic_prometheus_exporter/tests/data2.json
+++ b/ironic_prometheus_exporter/tests/data2.json
@@ -1,15 +1,15 @@
 {
     "priority": "INFO",
     "event_type": "hardware.ipmi.metrics",
-    "timestamp": "2019-03-29 20:12:26.885347",
+    "timestamp": "2019-03-29 20:15:26.885347",
     "publisher_id": "None.localhost.localdomain",
     "payload": {
-        "instance_uuid": "ac2aa2fd-6e1a-41c8-a114-2084c8705228",
-        "node_uuid": "ac2aa2fd-6e1a-41c8-a114-2084c8705228",
+        "instance_uuid": "6d85703a-565d-469a-96ce-30b6de53079d",
+        "node_uuid": "6d85703a-565d-469a-96ce-30b6de53079d",
         "event_type": "hardware.ipmi.metrics.update",
-        "timestamp": "2019-03-29T20:22:22.989020",
+        "timestamp": "2019-03-29T20:15:22.989020",
         "node_name": "knilab-master-u8",
-        "message_id": "85d6b2c8-fe57-432d-868a-330e0e28cf34",
+        "message_id": "d2b30520-907d-46c8-bfee-c5586e6fb3a1",
         "payload": {
             "Management": {
                 "Front LED Panel (0x23)": {

--- a/ironic_prometheus_exporter/tests/test_driver.py
+++ b/ironic_prometheus_exporter/tests/test_driver.py
@@ -35,8 +35,10 @@ class TestPrometheusFileNotifier(test_utils.BaseTestCase):
         msg1 = json.load(open('./ironic_prometheus_exporter/tests/data.json'))
         node1 = msg1['payload']['node_name']
         msg2 = json.load(open('./ironic_prometheus_exporter/tests/data2.json'))
-        # Override data2 node_name
+        # Override data2 node_name, node_uuid, instance_uuid
         msg2['payload']['node_name'] = node1
+        msg2['payload']['node_uuid'] = msg1['payload']['node_uuid']
+        msg2['payload']['instance_uuid'] = msg1['payload']['instance_uuid']
         node2 = msg2['payload']['node_name']
         self.assertNotEqual(msg1['payload']['timestamp'],
                             msg2['payload']['timestamp'])

--- a/ironic_prometheus_exporter/tests/test_ipmi_parser.py
+++ b/ironic_prometheus_exporter/tests/test_ipmi_parser.py
@@ -12,6 +12,9 @@ class TestPayloadsParser(unittest.TestCase):
 
     def setUp(self):
         self.node_name = DATA['payload']['node_name']
+        self.node_uuid = DATA['payload']['node_uuid']
+        self.instance_uuid = DATA['payload']['instance_uuid']
+        self.timestamp = DATA['payload']['timestamp']
         self.payload = DATA['payload']['payload']
         self.metric_registry = CollectorRegistry()
 
@@ -27,13 +30,17 @@ class TestPayloadsParser(unittest.TestCase):
         self.assertIn('baremetal_front_led_panel', management_metrics_name)
 
         ipmi.prometheus_format(self.payload['Management'], self.node_name,
-                               self.metric_registry, management_metrics_name,
-                               ipmi_format)
+                               self.node_uuid, self.instance_uuid,
+                               self.metric_registry,
+                               management_metrics_name, ipmi_format)
 
         self.assertEqual(0.0, self.metric_registry.get_sample_value(
             'baremetal_front_led_panel',
             {'node_name': 'knilab-master-u9',
-             'entity_id': '7.1 (System Board)'}))
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'sensor_id': 'Front LED Panel (0x23)'}))
 
     def test_temperature_parser(self):
         prefix = ipmi.CATEGORY_PARAMS['temperature']['prefix']
@@ -49,24 +56,40 @@ class TestPayloadsParser(unittest.TestCase):
         self.assertIn('baremetal_inlet_temp_celsius', temperature_metrics_name)
 
         ipmi.prometheus_format(self.payload['Temperature'], self.node_name,
-                               self.metric_registry, temperature_metrics_name,
-                               ipmi_format)
-
+                               self.node_uuid, self.instance_uuid,
+                               self.metric_registry,
+                               temperature_metrics_name, ipmi_format)
         self.assertEqual(21.0, self.metric_registry.get_sample_value(
-            'baremetal_inlet_temp_celsius', {'node_name': self.node_name,
-                                             'entity_id': '7.1 (System Board)'}
+            'baremetal_inlet_temp_celsius',
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'sensor_id': 'Inlet Temp (0x5)',
+             'status': 'ok'}
         ))
         self.assertEqual(36.0, self.metric_registry.get_sample_value(
             'baremetal_exhaust_temp_celsius',
-            {'node_name': self.node_name, 'entity_id': '7.1 (System Board)'}))
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'sensor_id': 'Exhaust Temp (0x6)',
+             'status': 'ok'}))
         self.assertEqual(44.0, self.metric_registry.get_sample_value(
             'baremetal_temp_celsius', {'node_name': self.node_name,
                                        'sensor_id': 'Temp (0x1)',
-                                       'entity_id': '3.1 (Processor)'}))
+                                       'node_uuid': self.node_uuid,
+                                       'instance_uuid': self.instance_uuid,
+                                       'entity_id': '3.1 (Processor)',
+                                       'status': 'ok'}))
         self.assertEqual(43.0, self.metric_registry.get_sample_value(
             'baremetal_temp_celsius', {'node_name': self.node_name,
                                        'sensor_id': 'Temp (0x2)',
-                                       'entity_id': '3.2 (Processor)'}))
+                                       'node_uuid': self.node_uuid,
+                                       'instance_uuid': self.instance_uuid,
+                                       'entity_id': '3.2 (Processor)',
+                                       'status': 'ok'}))
 
     def test_system_parser(self):
         prefix = ipmi.CATEGORY_PARAMS['system']['prefix']
@@ -80,15 +103,24 @@ class TestPayloadsParser(unittest.TestCase):
         self.assertIn('baremetal_system_post_err', system_metrics_name)
 
         ipmi.prometheus_format(self.payload['System'], self.node_name,
-                               self.metric_registry, system_metrics_name,
-                               ipmi_format)
+                               self.node_uuid, self.instance_uuid,
+                               self.metric_registry,
+                               system_metrics_name, ipmi_format)
         self.assertEqual(0.0, self.metric_registry.get_sample_value(
             'baremetal_system_unknown',
-            {'node_name': self.node_name, 'entity_id': '34.1 (BIOS)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '34.1 (BIOS)',
+             'sensor_id': 'Unknown (0x8)'}
         ))
         self.assertEqual(None, self.metric_registry.get_sample_value(
             'baremetal_system_post_err',
-            {'node_name': self.node_name, 'entity_id': '34.1 (BIOS)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '34.1 (BIOS)',
+             'sensor_id': 'POST Err (0x1e)'}
         ))
 
     def test_current_parser(self):
@@ -103,21 +135,35 @@ class TestPayloadsParser(unittest.TestCase):
         self.assertIn('baremetal_pwr_consumption', current_metrics_name)
 
         ipmi.prometheus_format(self.payload['Current'], self.node_name,
-                               self.metric_registry, current_metrics_name,
-                               ipmi_format)
+                               self.node_uuid, self.instance_uuid,
+                               self.metric_registry,
+                               current_metrics_name, ipmi_format)
         self.assertEqual(264.0, self.metric_registry.get_sample_value(
             'baremetal_pwr_consumption',
-            {'node_name': self.node_name, 'entity_id': '7.1 (System Board)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'sensor_id': 'Pwr Consumption (0x76)',
+             'status': 'ok'}
         ))
         self.assertEqual(0.600, self.metric_registry.get_sample_value(
             'baremetal_current',
-            {'node_name': self.node_name, 'entity_id': '10.1 (Power Supply)',
-             'sensor_id': 'Current 1 (0x6b)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '10.1 (Power Supply)',
+             'sensor_id': 'Current 1 (0x6b)',
+             'status': 'ok'}
         ))
         self.assertEqual(0.600, self.metric_registry.get_sample_value(
             'baremetal_current',
-            {'node_name': self.node_name, 'entity_id': '10.2 (Power Supply)',
-             'sensor_id': 'Current 2 (0x6c)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '10.2 (Power Supply)',
+             'sensor_id': 'Current 2 (0x6c)',
+             'status': 'ok'}
         ))
 
     def test_version_parser(self):
@@ -134,19 +180,32 @@ class TestPayloadsParser(unittest.TestCase):
         self.assertIn('baremetal_chassis_mismatch', version_metrics_name)
 
         ipmi.prometheus_format(self.payload['Version'], self.node_name,
-                               self.metric_registry, version_metrics_name,
-                               ipmi_format)
+                               self.node_uuid, self.instance_uuid,
+                               self.metric_registry,
+                               version_metrics_name, ipmi_format)
         self.assertEqual(1.0, self.metric_registry.get_sample_value(
             'baremetal_tpm_presence',
-            {'node_name': self.node_name, 'entity_id': '34.1 (BIOS)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '34.1 (BIOS)',
+             'sensor_id': 'TPM Presence (0x41)'}
         ))
         self.assertEqual(None, self.metric_registry.get_sample_value(
             'baremetal_hdwr_version_err',
-            {'node_name': self.node_name, 'entity_id': '34.1 (BIOS)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '34.1 (BIOS)',
+             'sensor_id': 'Hdwr version err (0x1f)'}
         ))
         self.assertEqual(0.0, self.metric_registry.get_sample_value(
             'baremetal_chassis_mismatch',
-            {'node_name': self.node_name, 'entity_id': '34.1 (BIOS)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '34.1 (BIOS)',
+             'sensor_id': 'Chassis Mismatch (0x37)'}
         ))
 
     def test_memory_parser(self):
@@ -173,48 +232,89 @@ class TestPayloadsParser(unittest.TestCase):
         self.assertIn('baremetal_memory_spared', memory_metrics_name)
 
         ipmi.prometheus_format(self.payload['Memory'], self.node_name,
-                               self.metric_registry, memory_metrics_name,
-                               ipmi_format)
+                               self.node_uuid, self.instance_uuid,
+                               self.metric_registry,
+                               memory_metrics_name, ipmi_format)
 
         self.assertEqual(None, self.metric_registry.get_sample_value(
             'baremetal_mem_ecc_warning',
-            {'node_name': self.node_name, 'entity_id': '34.1 (BIOS)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '34.1 (BIOS)',
+             'sensor_id': 'Mem ECC Warning (0x1b)'}
         ))
         self.assertEqual(1.0, self.metric_registry.get_sample_value(
             'baremetal_memory_post_pkg_repair',
-            {'node_name': self.node_name, 'entity_id': '34.1 (BIOS)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '34.1 (BIOS)',
+             'sensor_id': 'POST Pkg Repair (0x45)'}
         ))
         self.assertEqual(0.0, self.metric_registry.get_sample_value(
             'baremetal_idpt_mem_fail',
-            {'node_name': self.node_name, 'entity_id': '34.1 (BIOS)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '34.1 (BIOS)',
+             'sensor_id': 'iDPT Mem Fail (0x2b)'}
         ))
         self.assertEqual(0.0, self.metric_registry.get_sample_value(
             'baremetal_memory_spared',
-            {'node_name': self.node_name, 'entity_id': '34.1 (BIOS)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '34.1 (BIOS)',
+             'sensor_id': 'Memory Spared (0x11)'}
         ))
         self.assertEqual(0.0, self.metric_registry.get_sample_value(
             'baremetal_memory_mirrored',
-            {'node_name': self.node_name, 'entity_id': '34.1 (BIOS)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '34.1 (BIOS)',
+             'sensor_id': 'Memory Mirrored (0x12)'}
         ))
         self.assertEqual(None, self.metric_registry.get_sample_value(
             'baremetal_memory_usb_over_current',
-            {'node_name': self.node_name, 'entity_id': '34.1 (BIOS)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '34.1 (BIOS)',
+             'sensor_id': 'USB Over-current (0x1d)'}
         ))
         self.assertEqual(1.0, self.metric_registry.get_sample_value(
             'baremetal_memory_ecc_uncorr_err',
-            {'node_name': self.node_name, 'entity_id': '34.1 (BIOS)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '34.1 (BIOS)',
+             'sensor_id': 'ECC Uncorr Err (0x2)'}
         ))
         self.assertEqual(0.0, self.metric_registry.get_sample_value(
             'baremetal_memory_b',
-            {'node_name': self.node_name, 'entity_id': '32.1 (Memory Device)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '32.1 (Memory Device)',
+             'sensor_id': 'B  (0xd6)'}
         ))
         self.assertEqual(0.0, self.metric_registry.get_sample_value(
             'baremetal_memory_a',
-            {'node_name': self.node_name, 'entity_id': '32.1 (Memory Device)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '32.1 (Memory Device)',
+             'sensor_id': 'A  (0xca)'}
         ))
         self.assertEqual(1.0, self.metric_registry.get_sample_value(
             'baremetal_memory_ecc_corr_err',
-            {'node_name': self.node_name, 'entity_id': '34.1 (BIOS)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '34.1 (BIOS)',
+             'sensor_id': 'ECC Corr Err (0x1)'}
         ))
 
     def test_power_parser(self):
@@ -229,24 +329,32 @@ class TestPayloadsParser(unittest.TestCase):
         self.assertIn('baremetal_power_status', power_metrics_name)
 
         ipmi.prometheus_format(self.payload['Power'], self.node_name,
-                               self.metric_registry, power_metrics_name,
-                               ipmi_format)
+                               self.node_uuid, self.instance_uuid,
+                               self.metric_registry,
+                               power_metrics_name, ipmi_format)
 
         self.assertEqual(None, self.metric_registry.get_sample_value(
             'baremetal_power_ps_redundancy',
-            {'node_name': self.node_name, 'entity_id': '7.1 (System Board)'}
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'sensor_id': 'PS Redundancy (0x77)'}
         ))
         self.assertEqual(0.0, self.metric_registry.get_sample_value(
             'baremetal_power_status', {'node_name': self.node_name,
                                        'sensor_id': 'Status (0x86)',
+                                       'node_uuid': self.node_uuid,
+                                       'instance_uuid': self.instance_uuid,
                                        'entity_id': '10.2 (Power Supply)'}))
         self.assertEqual(0.0, self.metric_registry.get_sample_value(
             'baremetal_power_status', {'node_name': self.node_name,
                                        'sensor_id': 'Status (0x85)',
+                                       'node_uuid': self.node_uuid,
+                                       'instance_uuid': self.instance_uuid,
                                        'entity_id': '10.1 (Power Supply)'}))
 
     def test_watchdog2_parser(self):
-        print('WATCHDOG2')
         prefix = ipmi.CATEGORY_PARAMS['watchdog2']['prefix']
         sufix = ipmi.CATEGORY_PARAMS['watchdog2']['sufix']
         extra = ipmi.CATEGORY_PARAMS['watchdog2']['extra_params']
@@ -258,16 +366,24 @@ class TestPayloadsParser(unittest.TestCase):
         self.assertIn('baremetal_os_watchdog', watchdog2_metrics_name)
 
         ipmi.prometheus_format(self.payload['Watchdog2'], self.node_name,
-                               self.metric_registry, watchdog2_metrics_name,
-                               ipmi_format)
+                               self.node_uuid, self.instance_uuid,
+                               self.metric_registry,
+                               watchdog2_metrics_name, ipmi_format)
 
         self.assertEqual(0.0, self.metric_registry.get_sample_value(
-            'baremetal_os_watchdog_time', {'node_name': self.node_name,
-                                           'entity_id': '34.1 (BIOS)'}
+            'baremetal_os_watchdog_time',
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '34.1 (BIOS)',
+             'sensor_id': 'OS Watchdog Time (0x23)'}
         ))
         self.assertEqual(0.0, self.metric_registry.get_sample_value(
             'baremetal_os_watchdog', {'node_name': self.node_name,
-                                      'entity_id': '7.1 (System Board)'}
+                                      'node_uuid': self.node_uuid,
+                                      'instance_uuid': self.instance_uuid,
+                                      'entity_id': '7.1 (System Board)',
+                                      'sensor_id': 'OS Watchdog (0x71)'}
         ))
 
     def test_fan_parser(self):
@@ -277,79 +393,160 @@ class TestPayloadsParser(unittest.TestCase):
         ipmi_format = ipmi.CATEGORY_PARAMS['fan']['use_ipmi_format']
         fan_metrics_name = ipmi.metric_names(self.payload['Fan'], prefix,
                                              sufix, **extra)
+
         self.assertEqual(len(fan_metrics_name), 2)
-        self.assertIn('baremetal_fan_redundancy_rpm', fan_metrics_name)
+        self.assertIn('baremetal_fan_redundancy', fan_metrics_name)
         self.assertIn('baremetal_fan_rpm', fan_metrics_name)
 
         ipmi.prometheus_format(self.payload['Fan'], self.node_name,
-                               self.metric_registry, fan_metrics_name,
-                               ipmi_format)
+                               self.node_uuid, self.instance_uuid,
+                               self.metric_registry,
+                               fan_metrics_name, ipmi_format)
 
         self.assertEqual(0.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_redundancy_rpm', {'node_name': self.node_name,
-                                             'entity_id': '7.1 (System Board)'}
+            'baremetal_fan_redundancy',
+            {'node_name': self.node_name,
+             'entity_id': '7.1 (System Board)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'sensor_id': 'Fan Redundancy (0x78)'}
         ))
         self.assertEqual(9960.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan4A (0x3b)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan4A (0x3b)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
         self.assertEqual(5520.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan1B (0x40)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan1B (0x40)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
         self.assertEqual(5520.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan8B (0x47)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan8B (0x47)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
         self.assertEqual(9360.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan3A (0x3a)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan3A (0x3a)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
         self.assertEqual(9360.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan2A (0x39)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan2A (0x39)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
         self.assertEqual(5520.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan6B (0x45)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan6B (0x45)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
         self.assertEqual(9720.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan5A (0x3c)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan5A (0x3c)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
         self.assertEqual(5520.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan3B (0x42)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan3B (0x42)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
         self.assertEqual(9360.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan7A (0x3e)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan7A (0x3e)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
         self.assertEqual(5520.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan7B (0x46)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan7B (0x46)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
         self.assertEqual(5880.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan4B (0x43)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan4B (0x43)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
         self.assertEqual(9360.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan1A (0x38)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan1A (0x38)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
         self.assertEqual(9360.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan6A (0x3d)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan6A (0x3d)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
         self.assertEqual(5520.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan2B (0x41)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan2B (0x41)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
         self.assertEqual(5640.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan5B (0x44)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan5B (0x44)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
         self.assertEqual(9240.0, self.metric_registry.get_sample_value(
-            'baremetal_fan_rpm', {'node_name': self.node_name,
-                                  'sensor_id': 'Fan8A (0x3f)',
-                                  'entity_id': '7.1 (System Board)'}))
+            'baremetal_fan_rpm',
+            {'node_name': self.node_name,
+             'sensor_id': 'Fan8A (0x3f)',
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid,
+             'entity_id': '7.1 (System Board)',
+             'status': 'ok'}))
+
+    def test_timestamp_metric(self):
+        ipmi.timestamp_registry(self.timestamp, self.node_name, self.node_uuid,
+                                self.instance_uuid, self.metric_registry)
+
+        self.assertEqual(1553890342.0, self.metric_registry.get_sample_value(
+            'baremetal_last_payload_timestamp',
+            {'node_name': self.node_name,
+             'node_uuid': self.node_uuid,
+             'instance_uuid': self.instance_uuid}
+        ))


### PR DESCRIPTION
 Updates and Fixes for metrics labels

- Added new fields to labels: `timestamp`, `node_uuid` and
`instance_uuid`.
- Updated the support for the new labels in the driver
- Fixed `extract_unit` in the `metric_names` function
- Changed regex in the `metric_names` function and added
examples to help understand what each regex will do.
- Updated tests
- Updated `data2.json` to have different information
for the new labels